### PR TITLE
Fixed an error in `getHFDitemavail`

### DIFF
--- a/TR1/HMDHFDplus/R/HFDutils.R
+++ b/TR1/HMDHFDplus/R/HFDutils.R
@@ -188,6 +188,12 @@ getHFDitemavail <- function(CNTRY){
     X |>
       clean_names() |>
       rename("measure" = .data$x) |> 
+
+      # "Converting Numeric Columns to Character Columns"
+      # e.g., on HFD, item = "tfrRR", 
+      # `census_or_register_based_parity_estimates` is numeric 
+      mutate_if(is.numeric, as.character) |>       
+            
       pivot_longer(-.data$measure,names_to = "subtype",values_to = "years") |> 
       filter(.data$measure != "")
   }


### PR DESCRIPTION
Hi Tim, 

Recently while trying to import data from the HFD web using `readHFDweb`, I encountered an error. After some investigation, I discovered that certain parity-specific data columns were in numeric format, causing an issue with collecting column names in `getHFDitemavail`. 
To revolve this issue, I made a small modification in `HFDutils.R`  by adding a line of code to convert all numeric columns to character format. I think that this should address the issue. 
Thank you. 

- Sam 