### PR TITLE
Don't list default Language

### DIFF
--- a/TR1/HMDHFDplus/DESCRIPTION
+++ b/TR1/HMDHFDplus/DESCRIPTION
@@ -40,4 +40,3 @@ Imports:
 Suggests:
     RCurl
 RoxygenNote: 7.2.3
-Language: 'en-US'


### PR DESCRIPTION
https://cran.r-project.org/doc/manuals/r-release/R-exts.html#The-DESCRIPTION-file

This mentions using `Language` _only if_ the documentation is not in English. There can be some semantic hashing here about whether `en-US` is a specific enough improvement over generic `en` to warrant mention, but I think not. Anyway, `'en-US'` should not be quoted (this is the only CRAN package that does so).